### PR TITLE
Added quotes around the file path 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,20 @@
 'use strict';
 
-var exec = require('child_process').exec;
 var plist = require('simple-plist');
+var os = require('os').platform();
 
 module.exports = function(path, callback){
-  exec('codesign -d --entitlements :- ' + path, function(error, output){
-    if(error){
-      return callback(error);
-    }
-
-    callback(null, plist.parse(output));
-  });
+  if(os === 'darwin') {
+    var exec = require('child_process').exec;
+    exec('codesign -d --entitlements :- ' + path, function(error, output){
+      if(error){
+        return callback(error);
+      }
+      console.log(output);
+      callback(null, plist.parse(output));
+    });
+  } else {
+    console.log('nothing');
+    callback(null, {});
+  }
 };

--- a/index.js
+++ b/index.js
@@ -1,20 +1,14 @@
 'use strict';
 
+var exec = require('child_process').exec;
 var plist = require('simple-plist');
-var os = require('os').platform();
 
 module.exports = function(path, callback){
-  if(os === 'darwin') {
-    var exec = require('child_process').exec;
-    exec('codesign -d --entitlements :- ' + path, function(error, output){
-      if(error){
-        return callback(error);
-      }
-      console.log(output);
-      callback(null, plist.parse(output));
-    });
-  } else {
-    console.log('nothing');
-    callback(null, {});
-  }
+  exec('codesign -d --entitlements :- "' + path + '"', function(error, output){
+    if(error){
+      return callback(error);
+    }
+
+    callback(null, plist.parse(output));
+  });
 };


### PR DESCRIPTION
Hi,

I've added quotation marks around the path element of the exec so it doesn't fail if the path contains whitespaces. I hit this issue a few months back in the certificate downloader and patched it there too (0.2.0 @https://github.com/evi-snowm/cert-downloader/tree/0.2.0). Saw you updated https://github.com/matiassingers/provisioning to include this version already, thanks!
